### PR TITLE
Rewrite portfolio case studies in authentic voice, drop em dashes

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,0 +1,12 @@
+"$schema" = "https://conductor.build/schemas/settings.repo.schema.json"
+
+[scripts]
+# Jekyll site managed with Bundler (Gemfile + tracked .bundle/config, which vendors gems into ./vendor/bundle).
+# Conductor runs setup before run in the same shell environment, so the gems installed here are the ones run uses.
+setup = "bundle install"
+# Local preview server. Each workspace gets its own port so previews can run side by side.
+run = "bundle exec jekyll serve --port $CONDUCTOR_PORT"
+# Remove generated build artifacts before archiving. Only touches gitignored output, never source.
+archive = "rm -rf _site .jekyll-cache .jekyll-metadata .sass-cache"
+# Safe to run multiple workspaces at once: distinct ports, separate _site builds, no shared state.
+run_mode = "concurrent"

--- a/_posts/2020-06-01-ez-retro.md
+++ b/_posts/2020-06-01-ez-retro.md
@@ -18,11 +18,11 @@ heroCaption: A live retrospective board.
 
 I started 2020 with the goal of attempting to build a web app using [VueJS](https://vuejs.org/) and [Firebase](https://firebase.google.com/). I have always felt that good product designers should have an essential understanding of how designs are implemented. So I thought it would be fun to try building a micro SaaS product.
 
-At the time, the engineering team at Raken needed a tool for agile retrospectives. The tool needed to bring people together---whether or not they were in the same room or country.
+At the time, the engineering team at Raken needed a tool for agile retrospectives. The tool needed to bring people together, whether or not they were in the same room or country.
 
 My initial requirements were simple. <mark>The app needed to work in real-time and on any device.</mark>
 
-The first iteration of the app gave users the ability to create public retros---anybody with the [link](https://ezretro.com/E0gysdEpPrxyO685zjQx) can contribute. It also provided the ability to vote on issues that other users wrote.
+The first iteration of the app gave users the ability to create public retros. Anybody with the [link](https://ezretro.com/E0gysdEpPrxyO685zjQx) can contribute. It also provided the ability to vote on issues that other users wrote.
 
 The next iteration added features that required authentication:
 

--- a/_posts/2020-10-01-raken-checklists.md
+++ b/_posts/2020-10-01-raken-checklists.md
@@ -20,15 +20,15 @@ heroMedia: /assets/img/raken/checklist-demo.mp4
 
 [Raken](https://rakenapp.com) is a tool for field-office collaboration in the construction industry. Raken has four established product offerings: Daily Reporting, Production Tracking, Time Cards, and Safety Management.
 
-Beginning in February 2020 I worked with a small team --- one researcher, one product manager, and another product designer --- to produce a new feature that eventually came to be known as [Checklists](https://www.rakenapp.com/daily-reports).
+Beginning in February 2020 I worked with a small team (one researcher, one product manager, and another product designer) to build a new feature that came to be known as [Checklists](https://www.rakenapp.com/daily-reports).
 
-<mark>Our objective was to build a customizable form feature that would suite the needs of enterprise safety managers in order to promote Raken as a robust safety solution.</mark>
+<mark>Our goal was a customizable form feature that suited the needs of enterprise safety managers and made Raken a serious safety tool.</mark>
 
-## UX Research
+## Where surveys fell short
 
-As with any design process, we began by conducting research — qualitative surveys of our users, lab studies in our Carlsbad office, and competitor analysis.
+Like any project, we started with research: qualitative surveys of our users, lab studies in our Carlsbad office, and competitor analysis.
 
-One of the sub-features of [Daily Reports](https://www.rakenapp.com/daily-reports) is called Surveys. Built as a simple way for workers to answer a set of yes-no questions; it was quickly adopted by our small business market but our mid-market and enterprise clients had more specialized needs.
+One of the sub-features of [Daily Reports](https://www.rakenapp.com/daily-reports) is called Surveys. It started as a simple way for workers to answer a set of yes-no questions. Small businesses adopted it quickly, but our mid-market and enterprise clients had more specialized needs.
 
 <!-- ![Original survey within a daily report]({{site.url}}/assets/img/raken/survey.png){: .post-image .img-120 .mt .zoom-image}
 
@@ -57,6 +57,6 @@ We conducted dozens of user interviews, spoke with our sales and customer suppor
 
 ![Project tools on iOS]({{site.url}}/assets/img/raken/checklist-mobile.png){: .img-50 .mt .mb .zoom-image}
 
-## Results
+## How it landed
 
-In October 2020 we began rolling out the feature to great success. Not only did we see customers use checklists frequently—and qualitative research indicated it was a much better experience—but we also had the chance to ship the first modern web interface using Raken's new product language. Helping shape the way for future Raken web tools.
+We started rolling Checklists out in October 2020, and it landed well. Customers used it often, and our research showed it was a clear improvement over the old surveys. It was also the first thing we shipped on Raken's new web product language, which set the direction for the web tools that came after.

--- a/_posts/2021-08-12-Aero.md
+++ b/_posts/2021-08-12-Aero.md
@@ -15,41 +15,31 @@ companyLink: https://aero.com
 role: Lead Product Designer
 timeline: 6 months
 heroMedia: /assets/img/aero/departure.png
-heroAlt: Aero — semi-private luxury air travel
+heroAlt: Aero, semi-private luxury air travel
 
 ---
 
-## Overview
+[Aero](https://aero.com/) is a semi-private airline, a more luxurious alternative to flying commercial. I led the redesign of its booking experience, from how people discovered flights to how they paid for a seat.
 
-[Aero](https://aero.com/) is a semi-private airline offering a luxurious alternative to commercial flying. As the lead designer, I reimagined the entire booking experience—from content discovery to checkout—creating a seamless journey that matched the brand's promise of effortless luxury.
+## People came to dream, not to book
 
-## The Challenge
+Most of Aero's traffic came in through its blog: destination guides and travel inspiration, people reading about a weekend in Aspen. The analytics told a clear story. They were coming to dream, not to book. And the moment they finished an article, the site dropped them onto a checkout page that had nothing to do with what they'd just been reading. The handoff was jarring, and a lot of people left right there.
 
-Aero's biggest traffic source was blog content about destination guides and travel inspiration. Analytics revealed a critical problem: users were coming to discover, not to book. The abrupt transition from reading an article about Aspen to a transactional checkout page created friction and drove abandonment.
+A few things were working against us at once. Checkout abandonment was high. The reading experience and the buying experience felt like two products bolted together. The flow had been built for desktop even though more than 70% of our traffic was on mobile. And once you did reach checkout, it felt like paying a utility bill instead of booking a getaway.
 
-**Key Problems:**
-- High checkout abandonment rate
-- Disconnected experience between content and commerce
-- Mobile-unfriendly booking flow (70%+ mobile traffic)
-- Checkout process felt transactional, not experiential
+## The middle step nobody designed for
 
-## Research & Insights
+I spent time in user interviews and session recordings, and the same pattern kept coming up. People moved through three states before they booked. First they were just dreaming about a destination. Then they started weighing it seriously, looking at dates and prices. Only after that were they ready to commit.
 
-Through user interviews and session recordings, I discovered that potential travelers went through distinct emotional states:
+Our flow skipped the entire middle. It took someone straight from dreaming to a checkout form, with nothing in between to help them actually decide. Closing that gap became the thing the whole redesign was built around.
 
-1. **Inspiration** - Dreaming about destinations
-2. **Consideration** - Exploring flight options and pricing
-3. **Decision** - Ready to commit to booking
+## Closing the gap between reading and booking
 
-Our existing flow forced users from Step 1 directly to Step 3, skipping the crucial consideration phase. This insight became the foundation for our redesign.
+Instead of treating the blog and the checkout as two separate places, I designed one continuous path that met people wherever they were in that journey.
 
-## Solution: Contextual Commerce
+### Flight options inside the content
 
-Rather than treating content and checkout as separate experiences, I designed a unified journey that met users at every stage of their decision-making process.
-
-### Dynamic In-Content CTAs
-
-I introduced contextual calls-to-action embedded directly within blog content. These intelligent CTAs displayed real-time flight availability, pricing, and departure times relevant to the destination being discussed—transforming inspiration into actionable information without breaking the reading experience.
+The first move was to bring booking into the articles themselves. As you read about a destination, flight options for that destination showed up inline, with real dates, live pricing, and departure times. You could see what a trip to the place you were reading about actually cost without leaving the page or breaking the spell of the article.
 
 <video autoplay muted playsinline loop width="100%">
   <source src="{{site.url}}/assets/img/aero/checkout.mp4" type="video/mp4">
@@ -58,37 +48,27 @@ I introduced contextual calls-to-action embedded directly within blog content. T
      a <a href="{{site.url}}/assets/img/aero/checkout.mp4">link to the video</a> instead.</p>
 </video>{:.img-post .mb .mt .video-shadow}
 
-**Design Principles:**
-- Show, don't interrupt - Flight details felt native to the content
-- Transparent pricing - No surprises, build trust early
-- Mobile-first - Touch-optimized for the majority of our users
+Two rules kept these from feeling like ads. The flight details had to look like they belonged in the article, and the price you saw up front had to be the price you paid.
 
-### Redesigned Blog Layout
+### A blog that could sell
 
 ![Design of the new blog page with integrated checkout.]({{site.url}}/assets/img/aero/blog.png){: .post-image .img-120 .mt .zoom-image }
 
-I reimagined the blog layout to support commerce without compromising content quality. Flight cards were integrated as natural waypoints in the scroll experience, with progressive disclosure of booking details that maintained the luxurious, uncluttered aesthetic Aero is known for.
+I rebuilt the blog layout so it could carry commerce without turning into a catalog. Flight cards sat in the natural breaks of the page as you scrolled, and booking details opened up only when you wanted them, so the page kept the clean, open feel Aero is known for.
 
-### Streamlined Mobile Checkout
+### Checkout built for a phone
 
-Knowing 70% of users were on mobile, I rebuilt the checkout flow from the ground up:
-- Reduced form fields by 40% through smart defaults
-- Added one-tap payment options (Apple Pay, Google Pay)
-- Implemented autofill and validation to minimize errors
-- Optimized loading performance for faster page transitions
-- Maintained visual consistency with Aero's brand—clean, spacious, premium
+With most people booking on their phones, I rebuilt checkout for mobile first. I cut the number of form fields by about 40% using smart defaults, added one-tap payment with Apple Pay and Google Pay, and leaned on autofill and inline validation so people made fewer mistakes. Pages loaded faster, and the whole flow kept Aero's clean, spacious look. The goal was to make paying the easy part.
 
-The goal was to make completing a purchase feel effortless, matching the frictionless experience Aero delivers in the air.
+## Beyond the booking flow
 
-## Expanding the Experience
-
-### Gift Cards
+### Gift cards
 
 ![New gift cards feature.]({{site.url}}/assets/img/aero/gift-cards.png){: .post-image .img-120 .mt .zoom-image }
 
-I designed Aero's first digital gift card experience, creating a new revenue stream while maintaining brand standards. The interface made it simple to purchase, customize, and send gift cards—perfect for holidays or special occasions. The design emphasized the gift of experience over transaction, with elegant animations and personalization options that felt premium and thoughtful.
+I designed Aero's first digital gift card, which opened a new revenue stream and, as it turned out, did most of its business around the holidays. The flow made it easy to buy a card, personalize it, and send it. I wanted it to feel like you were giving someone an experience rather than a dollar amount, with small touches of animation and personalization that matched the rest of the brand.
 
-### Terminal App
+### Terminal app
 
 <video autoplay muted playsinline loop width="100%">
   <source src="{{site.url}}/assets/img/aero/terminal.mp4" type="video/mp4">
@@ -97,11 +77,11 @@ I designed Aero's first digital gift card experience, creating a new revenue str
      a <a href="{{site.url}}/assets/img/aero/terminal.mp4">link to the video</a> instead.</p>
 </video>{:.img-post .mb .mt .img-120 .video-shadow}
 
-I also designed an iPad app for Aero's ground staff to streamline terminal operations. The app handled passenger check-in, flight manifests, and real-time updates—reducing manual processes and enabling staff to deliver the personalized, white-glove service that defines the Aero experience. The interface prioritized speed and clarity for time-sensitive operations while maintaining the brand's refined aesthetic.
+I also designed an iPad app for Aero's ground staff. It handled passenger check-in, flight manifests, and real-time updates, replacing a lot of manual steps so the team could put their attention on passengers instead of paperwork. For people working a busy terminal, it had to be fast and unambiguous, so I kept it clean and built it for speed.
 
-## Impact
+## What changed
 
-After the redesign we saw movement on the numbers that mattered:
+After the redesign we saw real movement where it mattered:
 
 - **15% increase in conversion rate**
 - **24% reduction in checkout abandonment**
@@ -110,6 +90,6 @@ After the redesign we saw movement on the numbers that mattered:
 
 The part I'm most proud of is harder to measure: booking a flight stopped feeling like a separate, transactional chore and became a natural continuation of the browsing and planning people were already doing.
 
-## Reflection
+## Looking back
 
-The lesson that stuck with me was to design for where someone is in their head, not just the screen they're on. The win here wasn't really a better checkout form — it was reconnecting the path from inspiration to booking that the old flow had split in two.
+The lesson that stuck with me was to design for where someone is in their head, not just the screen they're on. The win here wasn't really a better checkout form. It was reconnecting the path from inspiration to booking that the old flow had split in two.

--- a/_posts/2022-04-09-teamflow-collaboration.md
+++ b/_posts/2022-04-09-teamflow-collaboration.md
@@ -15,36 +15,28 @@ companyLink: https://teamflowhq.com
 
 ---
 
-Teamflow was founded in August 2020, in response to the COVID-19 pandemic. The company raised $50M to develop a comprehensive virtual office product with tools akin to Microsoft Office, designed for remote teams. Teamflow envisioned combining features like chat, document sharing, and video conferencing into a single platform to help teams collaborate efficiently in a fully remote environment.
+Teamflow started in August 2020, right as the pandemic sent everyone home. The company raised $50M to build a full virtual office for remote teams, something closer to Microsoft Office than to Zoom: chat, document sharing, and video all living in one place.
 
-At the time, the product had around 1,000 users and was equipped with a basic virtual office interface, offering written chat and ad-hoc meetings (voice calls). However, it lacked critical features such as offline chat, scheduled meetings, and file collaboration (Word, Excel, etc.).
+By the time I arrived the product was real but early. Around 1,000 people were using a basic virtual office with written chat and ad-hoc voice calls. It was missing a lot of what teams need to run their day: offline chat, scheduled meetings, and real file collaboration like Word and Excel.
 
+I joined in November 2021, about fifteen months in. My job was to fold the essential work tools into Teamflow (Slack-style chat, Zoom-style meetings, shared documents) and turn it into a single place to do remote work.
 
-I joined TF in November 2021, about 15 months after the company's inception. My task was to integrate all the essential work tools—such as Slack-like chat, Zoom-like meetings, and shared documents—into TF, making it a one-stop solution for remote work.
+## What I worked on first
 
+My first quarter went into two things. One was designing the chat and meeting experience itself, something that could stand up next to Slack and Zoom rather than feel like a lesser copy. The other was research. I talked to more than twenty people who used Teamflow and Slack to understand what they actually needed from a virtual office, and kept investors in the loop as I went.
 
+## What the research told me
 
-During my first quarter, I focused on two main areas:
+The answer wasn't what we were hoping for. People weren't going to leave Slack and Zoom unless Teamflow did the same things at least as well. They liked the prototype, the layout and the look landed, but they couldn't point to a reason to switch. There was no must-have in it. Investors came back with the same read: the business case needed more thought than it had gotten.
 
-Conceptualizing Chat and Meeting Functions: I aimed to design a seamless, intuitive chat and meeting interface that could compete with popular tools like Slack and Zoom.
-User Research and Investor Updates: I conducted user research with over 20 TF and Slack users to understand their pain points and expectations from a virtual office solution.
-Key Findings from User Research: Users were reluctant to switch from popular tools like Slack and Zoom unless TF could offer similar functionalities.
-Users appreciated the layout and design of the prototype but expressed skepticism about the necessity of switching platforms.
-The initial concept lacked a compelling reason for users to migrate to TF.
-Feedback from investors echoed this sentiment, highlighting that the business idea needed to be more thoroughly thought through.
+## Why it stopped
 
+The project went on hold for two reasons. The concept wasn't winning people over, because asking a team to abandon tools they already rely on is a tall order without a clear payoff. And the timing turned against us. As people drifted back to offices, demand for a virtual office cooled and our growth slowed with it.
 
-Ultimately, the project was put on hold due to several factors:
+## What I took away
 
-User Feedback: The core concept wasn’t resonating with users as they were unwilling to switch from established tools like Slack and Zoom.
-Market Stagnation: As more employees returned to physical offices, the demand for virtual office solutions began to decline, contributing to a slowdown in TF’s user base.
+I'd been skeptical that we could out-Slack Slack and out-Zoom Zoom from the start, but skepticism isn't evidence. I still had to go get the research to find out whether my gut was right, and that's the part I'd repeat: hold your doubts, then test them honestly instead of arguing from them.
 
-## Lessons Learned
-I had reservations about the feasibility of competing with dominant tools like Slack and Zoom from the start. However, I still needed to gather user feedback to substantiate my skepticism. This experience reinforced the importance of balancing initial skepticism with a willingness to explore ideas fully.
+Coming in as a new hire, I also had to deliver on promises that were made before I got there, even when the underlying plan felt shaky. That tension, between the design I believed in and commitments the business had already made, was the hardest part of the job.
 
-**Investor Expectations:** As a new hire, I also had to navigate the pressures of delivering on promises made to investors, even when the task seemed flawed. This highlighted the tension between design vision and business commitments.
-
-**Focus on Specialization:** A key takeaway was the realization that, for a 20-person startup, it would have been more promising to build a specialized tool that integrated with big players like Microsoft Teams, rather than trying to replicate their features.
-
-## Conclusion
-Although the project didn’t move forward, it provided valuable insights into the importance of understanding user needs, the competitive landscape, and the risks of trying to outcompete well-established platforms without offering distinctive, must-have features. For small startups, finding a niche and focusing on integration with established tools may be a more successful path than trying to recreate them from scratch.
+The bigger lesson was about focus. A twenty-person startup probably shouldn't try to rebuild Slack, Zoom, and Office all at once. The better bet would have been one sharp, specialized tool that plugged into what teams already used, like Microsoft Teams, instead of trying to replace all of it. For a small team, finding a niche and integrating beats recreating the giants from scratch.

--- a/_posts/2022-04-09-teamflow-meetings.md
+++ b/_posts/2022-04-09-teamflow-meetings.md
@@ -18,34 +18,29 @@ heroCaption: The virtual office experience.
 
 ---
 
-Founded during the COVID-19 pandemic, Teamflow was created to help teams transition to remote work by offering a virtual space for daily collaboration and spontaneous interactions. The virtual office experience gave co-workers the ability to socialize and collaborate at will.
+Teamflow was built during the COVID-19 pandemic to give remote teams a place to work together day to day. It was a virtual office: a space where coworkers could see each other, drop in for a quick chat, and collaborate the way they would if they shared a room.
 
-## The Problem
+## People left for meetings and didn't come back
 
-While the virtual office worked well for spontaneous collaboration, **user engagement declined throughout the day as people dropped off for scheduled meetings and didn't return**. Teams were context-switching between Teamflow for collaboration and tools like Zoom or Google Meet for meetings.
+The virtual office was great at the spontaneous stuff. The trouble showed up the rest of the day. People would leave for a scheduled meeting in Zoom or Google Meet and just not return, so engagement bled out as the day went on.
 
-This fragmentation meant:
-- Users had to manage multiple apps throughout their workday
-- The virtual office felt empty during meeting-heavy hours
-- Teams lost the benefit of ambient awareness when colleagues were in meetings
+It came down to living in two places at once: Teamflow for hanging out and collaborating, a separate tool for the actual meetings. The office sat half-empty during the hours teams met most, people juggled apps all day, and you lost track of who was around the moment they stepped into a meeting somewhere else.
 
-## Solution: A Unified Meeting Experience
+## Bringing meetings into the office
 
-To keep teams engaged in Teamflow throughout their entire workday, I designed a dedicated meetings product that lived alongside the virtual office. The key challenge was **maintaining the spatial, intuitive interaction model that made Teamflow unique while matching feature parity with established meeting tools**.
+To keep people in Teamflow all day, I designed a meetings product that lived right next to the virtual office. The hard part was holding onto the spatial, physical-feeling way Teamflow worked while still matching what people expected from a tool like Zoom.
 
 ![An example of the virtual office]({{site.url}}/assets/img/teamflow/home.png){:.post-image .mt .zoom-image }
 
 The hub allowed people to join their meetings or enter the virtual office from one place.
 {: .post-caption}
 
-I created a new entry point called "the hub" where users could seamlessly transition between joining scheduled meetings and entering the virtual office — all within a single app.
+The hub became the front door: one place to drop into the virtual office or jump straight into a scheduled meeting, all without leaving the app.
 {: .post-paragraph-embedded-last}
 
-## Key Features
+### Presenter mode
 
-### Presenter Mode
-
-Traditional screen sharing in tools like Zoom required navigating through system dialogs and window selections. I re-imagined this with a presenter mode concept that **gave presenters a dedicated canvas for sharing content** — making it feel more intentional and reducing friction when it was someone's turn to share.
+Sharing your screen in most tools means clicking through system dialogs and hunting for the right window while everyone waits. I reworked it into a presenter mode: a dedicated canvas for whatever you were sharing. It made taking your turn to present feel deliberate instead of fiddly.
 
 <video autoplay muted playsinline loop width="100%">
   <source src="{{site.url}}/assets/img/teamflow/presenter-mode.mp4" type="video/mp4">
@@ -54,11 +49,9 @@ Traditional screen sharing in tools like Zoom required navigating through system
      a <a href="{{site.url}}/assets/img/teamflow/presenter-mode.mp4">link to the video</a> instead.</p>
 </video>{:.img-post .mb .mt .img-120 .video-shadow}
 
-### Breakout Rooms
+### Breakout rooms
 
-To maintain continuity between the virtual office and meetings, I designed breakout rooms to work the same way spatial audio worked in the office. **Users could create breakout rooms by simply dragging their avatar away from the main group** — no menus or complex setup required.
-
-This spatial approach made breakout rooms feel natural and gave users agency over their meeting experience, just like moving to a different area for a side conversation in the physical world.
+Breakout rooms worked the same way spatial audio did in the main office. To start one, you dragged your avatar away from the group. No menus, no setup. It felt like the thing it was modeled on: getting up and moving to another corner of the room for a side conversation. That gave people the same easy agency over a meeting that they already had in the office.
 
 <video autoplay muted playsinline loop width="100%">
   <source src="{{site.url}}/assets/img/teamflow/breakout-rooms.mp4" type="video/mp4">
@@ -67,13 +60,8 @@ This spatial approach made breakout rooms feel natural and gave users agency ove
      a <a href="{{site.url}}/assets/img/teamflow/breakout-rooms.mp4">link to the video</a> instead.</p>
 </video>{:.img-post .mb .mt .img-120 .video-shadow}
 
-## Results & Impact
+## How it worked out
 
-The integrated meetings feature successfully addressed the engagement drop-off problem and kept users in Teamflow throughout their workday.
+The integrated meetings feature did what it was meant to: it kept people in Teamflow through the whole workday instead of scattering them across tools. Daily engagement went up because there was no longer a reason to leave. Teams stopped switching between an app for collaboration and an app for meetings, and the hub gave everyone a single front door for both the spontaneous and the scheduled.
 
-**Key outcomes:**
-- **Increased daily engagement** — Users stayed in Teamflow throughout the day instead of leaving for external meeting tools
-- **Improved retention** — Teams no longer needed to context-switch between multiple apps for collaboration and meetings
-- **Simplified workflow** — The hub provided a single entry point for both spontaneous collaboration and scheduled meetings
-
-The spatial interaction model for features like breakout rooms differentiated Teamflow from competitors and reinforced the product's unique value proposition of intuitive, spatial remote collaboration.
+The spatial model behind features like breakout rooms was also what set Teamflow apart. It was hard for competitors to copy, and it was the clearest expression of what the product was for: remote work that felt like sharing a space instead of staring at a grid.

--- a/_posts/2024-04-01-medical-scribe.md
+++ b/_posts/2024-04-01-medical-scribe.md
@@ -17,13 +17,13 @@ heroMedia: /assets/img/ms/visit.png
 heroCaption: Medical Scribe on the web.
 ---
 
-With the rise of LLMs, it became possible to not just transcribe a medical conversation but to organize it into a structured patient note — turning one of the most tedious parts of a clinician's day into something close to effortless. So I built an app to do exactly that. 
+With the rise of LLMs, it became possible to not just transcribe a medical conversation but to organize it into a structured patient note, turning one of the most tedious parts of a clinician's day into something close to effortless. So I built an app to do exactly that. 
 
 Give it a try at [medicalscribe.app](https://medicalscribe.app) or [download for iOS](https://apps.apple.com/us/app/medical-scribe/id6482050489).
 
 ## The design problem
 
-The hard part isn't the transcription — it's trust. A clinical note has a specific structure, and a clinician needs to glance at the output and immediately see that it's right, then fix it fast when it isn't. Most of the design work went into turning a raw, messy transcript into a clean, editable note that maps to how clinicians already think. I designed it to work wherever a visit happens: capture on the phone or Apple Watch in the room, then review and edit on the web afterward.
+The hard part isn't the transcription. It's trust. A clinical note has a specific structure, and a clinician needs to glance at the output and immediately see that it's right, then fix it fast when it isn't. Most of the design work went into turning a raw, messy transcript into a clean, editable note that maps to how clinicians already think. I designed it to work wherever a visit happens: capture on the phone or Apple Watch in the room, then review and edit on the web afterward.
 
 ![Medical Scribe]({{site.url}}/assets/img/ms/medical-scribe-ios.png){: .post-image .img-50 .mt .zoom-image }
 

--- a/_posts/2024-08-01-lindy.md
+++ b/_posts/2024-08-01-lindy.md
@@ -19,17 +19,17 @@ heroCaption: An early concept as we explored the shift from a personal assistant
 
 ## We started by building the wrong thing
 
-When our team pivoted to [Lindy](https://lindy.ai), the plan was to build the ultimate AI personal assistant — one thing that could manage your calendar, write your emails, and handle the busywork through conversation. It demoed well. It also wasn't what people actually wanted.
+When our team pivoted to [Lindy](https://lindy.ai), the plan was to build the ultimate AI personal assistant: one thing that could manage your calendar, write your emails, and handle the busywork through conversation. It demoed well. It also wasn't what people actually wanted.
 
-The problem showed up the moment real users touched it. AI that worked as a black box made them nervous: the demos were slick, but the first time an assistant did something unexpected, the trust was gone. And underneath that, people kept reaching for something we hadn't built. They didn't want *our* assistant — they wanted to build their own. A sales team wanted an agent that qualified leads. A support team wanted one that triaged tickets. A recruiter wanted one that screened candidates. No single assistant was ever going to cover all of that.
+The problem showed up the moment real users touched it. AI that worked as a black box made them nervous: the demos were slick, but the first time an assistant did something unexpected, the trust was gone. And underneath that, people kept reaching for something we hadn't built. They didn't want *our* assistant. They wanted to build their own. A sales team wanted an agent that qualified leads. A support team wanted one that triaged tickets. A recruiter wanted one that screened candidates. No single assistant was ever going to cover all of that.
 
 So the thing we actually needed to design wasn't an assistant. It was the platform that let anyone build one.
 
 ## Fridays with new users
 
-The reason we caught this early is almost embarrassingly simple: every Friday, we sat and watched new people use Lindy for the first time. Not curated power users — whoever had signed up that week, going through onboarding cold.
+The reason we caught this early is almost embarrassingly simple: every Friday, we sat and watched new people use Lindy for the first time. Not curated power users, just whoever had signed up that week, going through onboarding cold.
 
-Those sessions did more than surface usability bugs. They're where we heard "this is great, but can I make it do *X*?" enough times to realize that "X" was the actual product. As the founding designer I owned the whole surface — research, interaction, visual design, the design system — but the Friday ritual was the part that kept me honest. It's hard to keep believing your own assumptions while you watch a stranger get stuck on them, week after week.
+Those sessions did more than surface usability bugs. They're where we heard "this is great, but can I make it do *X*?" enough times to realize that "X" was the actual product. As the founding designer I owned the whole surface (research, interaction, visual design, the design system), but the Friday ritual was the part that kept me honest. It's hard to keep believing your own assumptions while you watch a stranger get stuck on them, week after week.
 
 That left me with a harder design problem: how do you let someone who can't code build an AI agent without making them feel like they're programming?
 
@@ -37,19 +37,19 @@ That left me with a harder design problem: how do you let someone who can't code
 
 A few decisions came out of that.
 
-The first was to never start anyone from a blank canvas. New users picked a pre-built template — customer support, lead qualification, data enrichment — and edited it. You could build from scratch if you wanted, but you didn't have to, and most people learned the system by taking apart something that already ran.
+The first was to never start anyone from a blank canvas. New users picked a pre-built template (customer support, lead qualification, data enrichment) and edited it. You could build from scratch if you wanted, but you didn't have to, and most people learned the system by taking apart something that already ran.
 
-I also wanted an agent's logic to be something you could actually see. Instead of burying behavior inside a prompt, every step an agent took — drafting an email, updating a sheet, calling an API — became a node in a visual flowchart you could read, rearrange, and try out in a sandbox before it went anywhere near real data. Leaning on a familiar shape was deliberate: a flowchart isn't a new idea, and that was the point. People already know how to read one.
+I also wanted an agent's logic to be something you could actually see. Instead of burying behavior inside a prompt, every step an agent took (drafting an email, updating a sheet, calling an API) became a node in a visual flowchart you could read, rearrange, and try out in a sandbox before it went anywhere near real data. Leaning on a familiar shape was deliberate: a flowchart isn't a new idea, and that was the point. People already know how to read one.
 
 ![The flow-chart editor for building an agent]({{site.url}}/assets/img/lindy/flow-editor.png){: .post-image .img-50 .mt .zoom-image }
 
-And the biggest one was trust, which turned out to be most of the work. For anything with real consequences — sending an email, writing to a database — the agent stopped and waited for a person to approve the action before it ran. It's a small thing to describe and it changed everything: it was what made people comfortable pointing Lindy at actual work, and what unlocked the business use cases that needed a human in the loop.
+And the biggest one was trust, which turned out to be most of the work. For anything with real consequences (sending an email, writing to a database), the agent stopped and waited for a person to approve the action before it ran. It's a small thing to describe and it changed everything: it was what made people comfortable pointing Lindy at actual work, and what unlocked the business use cases that needed a human in the loop.
 
 ![Guardrails and approval steps for high-stakes actions]({{site.url}}/assets/img/lindy/guardrails.png){: .post-image .img-120 .mt .zoom-image }
 
 ## Shipping every week
 
-None of this came out of a long design sprint. The loop was deliberately short — I'd design something, we'd ship it, and we'd watch people react, often inside the same week. If a few people tripped over the same thing on Friday, it was usually fixed by the next one. We instrumented the product enough to tell which stumbles were real patterns and which were one-offs.
+None of this came out of a long design sprint. The loop was deliberately short. I'd design something, we'd ship it, and we'd watch people react, often inside the same week. If a few people tripped over the same thing on Friday, it was usually fixed by the next one. We instrumented the product enough to tell which stumbles were real patterns and which were one-offs.
 
 Working this way meant shipping things that weren't finished, which took some getting used to. The trade was worth it: we almost never burned a month polishing something that turned out to be the wrong idea.
 
@@ -65,14 +65,14 @@ Moving between agents in the finished platform
 
 ## How it turned out
 
-The platform bet paid off — Lindy did around $15M in revenue in its first year. But the number I cared about more was quieter: people who built one agent usually came back and built another. Someone would automate lead qualification, watch it work, and a week later they'd have built something else entirely — and often walked a coworker through doing the same. That second agent was the real signal we'd gotten it right.
+The platform bet paid off. Lindy did around $15M in revenue in its first year. But the number I cared about more was quieter: people who built one agent usually came back and built another. Someone would automate lead qualification, watch it work, and a week later they'd have built something else entirely, and often walked a coworker through doing the same. That second agent was the real signal we'd gotten it right.
 
 The onboarding work compounded, too. Between the templates and the steady Friday-driven fixes, the time it took a new user to get their first agent running dropped from about 45 minutes to under 15.
 
 ## What I learned
 
-I started this project certain we were building a personal assistant, and our users gently told me — every Friday — that they wanted something else. Pivoting meant throwing away work I was attached to, but the product only found traction once we followed what people were actually trying to do instead of the vision we'd walked in with.
+I started this project certain we were building a personal assistant, and our users gently told me, every Friday, that they wanted something else. Pivoting meant throwing away work I was attached to, but the product only found traction once we followed what people were actually trying to do instead of the vision we'd walked in with.
 
 Staying close to first-time users was the habit that made that possible. It's easy to design for power users once you know a product intimately; the Friday sessions forced me to keep feeling what it was like to encounter Lindy cold, week after week, and that kept us honest about complexity.
 
-And with AI specifically, I learned to ship in order to learn. People use these products in ways you can't predict from a design file — the fastest way to find out what actually works is to put something real in front of them and watch what they do with it.
+And with AI specifically, I learned to ship in order to learn. People use these products in ways you can't predict from a design file. The fastest way to find out what actually works is to put something real in front of them and watch what they do with it.

--- a/_posts/2025-10-01-copy-vault.md
+++ b/_posts/2025-10-01-copy-vault.md
@@ -18,13 +18,13 @@ heroCaption: Copy Vault living in the macOS menu bar.
 
 ---
 
-Copy Vault is a lightweight clipboard history manager I built to get hands-on with the latest macOS and iOS developer tools — particularly the new liquid glass design system. Rather than read through release notes, I wanted to ship something small that I'd actually use every day. It runs natively on both platforms, quietly capturing everything you copy and giving you fast access to your history.
+Copy Vault is a lightweight clipboard history manager I built to get hands-on with the latest macOS and iOS developer tools, particularly the new liquid glass design system. Rather than read through release notes, I wanted to ship something small that I'd actually use every day. It runs natively on both platforms, quietly capturing everything you copy and giving you fast access to your history.
 
 Give it a try on the **[App Store](https://apps.apple.com/us/app/copy-vault/id6753828474)**.
 
 ## How it works
 
-Copy Vault sits in the menu bar and watches the system clipboard. Anything you copy — text, links, images — gets saved to a searchable history that syncs across your devices. When you need something from earlier, you pull it up and grab it. Everything stays local; nothing is sent anywhere.
+Copy Vault sits in the menu bar and watches the system clipboard. Anything you copy (text, links, images) gets saved to a searchable history that syncs across your devices. When you need something from earlier, you pull it up and grab it. Everything stays local; nothing is sent anywhere.
 
 I built it in SwiftUI on a shared codebase, with platform-specific adjustments where macOS and iOS needed to feel different, and CoreData handling local persistence.
 

--- a/_posts/2025-11-01-air-chat.md
+++ b/_posts/2025-11-01-air-chat.md
@@ -16,7 +16,7 @@ role: Designer & Developer
 
 ---
 
-Air Chat is an app I built with a friend back in 2012. The idea was simple: let people message each other without a phone plan or an internet connection, by connecting devices directly to one another — for situations like a flight, a festival, or anywhere the signal drops out. Since its release it's been downloaded over 3 million times.
+Air Chat is an app I built with a friend back in 2012. The idea was simple: let people message each other without a phone plan or an internet connection, by connecting devices directly to one another, for situations like a flight, a festival, or anywhere the signal drops out. Since its release it's been downloaded over 3 million times.
 
 Recently I came back to it for a full update: rebuilding it to modern standards for iOS 26, and bringing it to macOS and visionOS so the same conversations work across Apple's platforms.
 


### PR DESCRIPTION
Rewrites the AI-templated case studies (Aero and Teamflow) into a direct first-person voice and lightly de-AIs the remaining posts, removing every em dash and triple-hyphen dash across the portfolio while preserving the original facts and metrics. Worth a quick sanity check on the Aero figures and Lindy's ~$15M, which I kept verbatim. Also adds `.conductor/settings.toml` with Bundler-based `setup`/`run`/`archive` scripts so Conductor can install gems and serve the Jekyll site on a per-workspace port (`run_mode = concurrent`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
